### PR TITLE
corrections concepts.tsv

### DIFF
--- a/etc/concepts.tsv
+++ b/etc/concepts.tsv
@@ -441,7 +441,7 @@ Hale-1973-1798-439	Animals-142	fight (animals)	v	03b.42
 Hale-1973-1798-440	Animals-143	bellow (bull)	v	03b.43		
 Hale-1973-1798-441	Animals-144	ride	v	03b.44	367	RIDE
 Hale-1973-1798-442	Animals-145	neigh	v	03b.45		
-Hale-1973-1798-443	Animals-146	give birth	v	03b.46		
+Hale-1973-1798-443	Animals-146	give birth	v	03b.46	1195	GIVE BIRTH
 Hale-1973-1798-444	Animals-147	castrate goats	v	03b.47		
 Hale-1973-1798-445	Animals-148	castrate bulls	v	03b.48		
 Hale-1973-1798-446	Animals-149	shear sheep	v	03b.49	1532	SHEAR
@@ -1264,7 +1264,7 @@ Hale-1973-1798-1262	Human_Mind_and_Conditions-150	flatter	v	10b1.77	2709	FLATTER
 Hale-1973-1798-1263	Human_Mind_and_Conditions-151	flirt	v	10b1.78	494	FLIRT
 Hale-1973-1798-1264	Human_Mind_and_Conditions-152	feel at ease	v	10b1.79		
 Hale-1973-1798-1265	Human_Mind_and_Conditions-153	quarrel with words	v	10b1.80		
-Hale-1973-1798-1266	Human_Mind_and_Conditions-154	quarrel	v	10b1.81		
+Hale-1973-1798-1266	Human_Mind_and_Conditions-154	quarrel	v	10b1.81	1848	QUARREL
 Hale-1973-1798-1267	Human_Mind_and_Conditions-155	separate	v	10b1.82	1359	SEPARATE
 Hale-1973-1798-1268	Human_Mind_and_Conditions-156	fail (in an attempt)	v	10b1.83		
 Hale-1973-1798-1269	Human_Mind_and_Conditions-157	succeed	v	10b1.84	1112	SUCCEED


### PR DESCRIPTION
Mapping removed:

1. 'fight (of animals)' is different from 'fight (of people)'.
Hale-1973-1798-439	Animals-142	fight (animals)	v	03b.42	1423	FIGHT

2. 'give birth (of animals)' is different from 'give birth (of humans)'.
Hale-1973-1798-443	Animals-146	give birth	v	03b.46	1195	GIVE BIRTH

3. 'thresh (rice and wheat)' is differentiated from 'thresh (millet, etc.)'; since the latter one has a broader meaning, it remains mapped to 285	THRESH. The mapping for thresh (rice and wheat) is removed.
Hale-1973-1798-545	Plants-98	thresh (rice and wheat)	v	04b.33	285	THRESH

4. 'heat up roti' has a very specific meaning
Hale-1973-1798-904	Food_and_Clothing-101	heat up roti	v	07b2.10	1341	HEAT UP

5. 'measure cloth' has a very specific meaning
Hale-1973-1798-950	Food_and_Clothing-147	measure cloth	v	07b3.13	1506	MEASURE

6. 1848 QUARREL is a noun, not a verb
Hale-1973-1798-1265	Human_Mind_and_Conditions-153	quarrel with words	v	10b1.80	1848	QUARREL
Hale-1973-1798-1266	Human_Mind_and_Conditions-154	quarrel	v	10b1.81	1848	QUARREL

7. 1495 HAPPY and 699 SAD are adjectives; additionally, the list 12a (or Attributes) contains 'happy' and 'sad'.
Hale-1973-1798-1318	Human_Mind_and_Conditions-206	be pleased, happy	v	10b3.16	1495	HAPPY
Hale-1973-1798-1319	Human_Mind_and_Conditions-207	be sad	v	10b3.17	699	SAD

Mapping added:

1. Hale-1973-1798-274	Human_Body-175	be numb	v	02b2.30	2216	BECOME NUMB
2. Hale-1973-1798-517	Plants-70	spoil	v	04b.06	569	BECOME SPOILED
3. Hale-1973-1798-625	Time_Weather_Geography-71	bank	n	05a.71	113	SHORE
4. Hale-1973-1798-784	House_and_Home-126	go out (fire)	v	06b3.05	2209	BECOME EXTINGUISHED